### PR TITLE
Rebuild for tesseract 4.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 3bca978dae9e03a327414d3da86954a943233a5169e25aaef14cddbb791d435a
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
   skip: true  # [win and py==27]
 


### PR DESCRIPTION
Even though this recipe only specifies a max pin of `x.x`, the tesseract recipe has `run_exports` of `x.x.x` so I found that the current tesserocr package that was built with tesseract 4.1.0 refuses to install with tesseract 4.1.1.

I just bumped the build number here to trigger a new package to be built, which should build (and run) with tesseract 4.1.1.